### PR TITLE
Fix ../ams/dataaccess/alchemy_dataaccess.py:86:8: N818 exception name…

### DIFF
--- a/ams/dataaccess/alchemy_dataaccess.py
+++ b/ams/dataaccess/alchemy_dataaccess.py
@@ -63,7 +63,7 @@ class SessionProxy():
 			self._session.rollback()
 			self._session.close()
 			if 'NotNullViolation' in str(e):
-				raise NotNullViolationException('Object violates not-null constraint.')
+				raise NotNullViolationExceptionError('Object violates not-null constraint.')
 			else:
 				raise e
 


### PR DESCRIPTION
… 'NotNullViolationException' should be named with an Error suffix.